### PR TITLE
Fix error 'Use of uninitialized value'

### DIFF
--- a/column_ansi.sh
+++ b/column_ansi.sh
@@ -1,9 +1,11 @@
 #!/bin/env bash
 
-# @description:    Perl version of column2 which works with color codes and is way faster than the bash version
-# @author:         Luca Salvarani
-# @source:         https://stackoverflow.com/a/38762316/8965861
-column_ansi () {
+# @description: Perl version of column2 which works with color codes and is way faster than the bash version
+# @author:      Luca Salvarani
+# @source:      https://stackoverflow.com/a/38762316/8965861
+# @git:         https://github.com/LukeSavefrogs/column_ansi
+column_ansi ()
+{
 	(
 		local __name="${FUNCNAME[0]}";
 		local __version="1.4.0";
@@ -71,7 +73,7 @@ column_ansi () {
 
 				sub trim_ansi {
 					my $__temp_string = $_[0];
-
+					if(!defined $__temp_string) { return ""; }
 					# Remove all Control Characters (color codes, carriage returns, bells and other characters)
 					$__temp_string =~ s/ \e[ #%()*+\-.\/]. |
 						\r | # Remove extra carriage returns also
@@ -142,6 +144,7 @@ column_ansi () {
 					my $column_index = 0;
 
 					foreach my $column (@columns) {
+						next if !defined $column;
 						$column = trim_ansi($column);
 
 						if (!defined $column_widths->[$column_index]) {
@@ -162,6 +165,7 @@ column_ansi () {
 					my $column_index = -1;
 
 					foreach my $column (@columns) {
+						next if !defined $column;
 						$column_index++;
 
 						# 2022/04/09 - Hide the column if it is in HIDDEN_COLUMNS

--- a/tests/test_column_ansi.sh
+++ b/tests/test_column_ansi.sh
@@ -142,6 +142,27 @@ if [[ $# -eq 0 ]]; then
 		printf "Test value${SEPARATOR}\033[1;35mColored output\033[0m${SEPARATOR}ABC${SEPARATOR}YES${SEPARATOR}Very long text\n";
 	);
 	sanitized_string="$(echo "${string}" | _trim_all_ANSI)"
+
+ 	string2="
+Current Date Time    :  \t
+ABC Reset            :  -- : \t
+ABC Reboot           :  --  \t
+Program Restart      :  -- : \t
+\f_
+\t
+Last    System Reboot: -- : \t\n
+Hostname             : dev-c1234some01 \tDevicename :
+ABC Master Server    :  \tOut-Nummer :
+Out Sync Protokoll   :  \tOS System  :
+SSH Authentication   :  \tTimeserver :
+IP-Address           :   \tGateway    :
+Subnetmask           :  \tDNS        :
+\t
+Out-Server           :  \tMain  check:
+System               :  \tABC Name   :
+UEFI System Check    :         \tBootorder  :
+System Up Time       :  \tRotation   :
+";
 	
 	printf "\033[1mCOLUMN (Original):\033[0m\n";
 	time echo "${string}" | column -t -s "${SEPARATOR}";
@@ -160,6 +181,11 @@ if [[ $# -eq 0 ]]; then
 
 	printf "\033[1mCOLUMN (Custom - mine):\033[0m\n";
 	time echo "${string}" | column_ansi -s "${SEPARATOR}";
+	printf "\n\n";
+
+
+	printf "\033[1mCOLUMN (Custom - mine): Empty Data without Ansi Codes\033[0m\n"
+	time echo -e -n "${string2}" | column_ansi -t -s $'\t'
 	printf "\n\n";
 else
 	# If script is NOT being sourced, then start the column_ansi function


### PR DESCRIPTION
Hey Luke!

Thanks for this amazing piece of code!

Had trouble with some input resulting in the following errors.
`Use of uninitialized value $__temp_string`
And after I fixed them for $__temp_string got the following
`Use of uninitialized value $column`

So I did some changes to get rid of them.
Your tests have ran successfully in /bin/bash on SLES 12.
![image](https://user-images.githubusercontent.com/14276298/179038215-b7ef665e-872d-4439-b6a6-41896e9171e3.png)

Be aware that this is my first time working with perl so I guess you should be extra critical of my changes made.

Let me know if you need anything from me.

Best Regards
Lukas