### PR TITLE
Keep quotes and backslashes

### DIFF
--- a/column_ansi.sh
+++ b/column_ansi.sh
@@ -141,11 +141,17 @@ column_ansi ()
 				foreach my $line_ref (@stdin) {
 					my $line = $line_ref;
 					$line =~ s/\r?\n?$//;
+					$line =~ s/(\\+)/$1$1/g;		# escape backslashes
+					$line =~ s/"/\\"/g;				# escape double quotes
+					$line =~ s/'"'"'/\\'"'"'/g;		# escape single quotes - complicated as we are in a bash single-quoted string
 					my @columns = quotewords($INPUT_SEPARATOR, 1, $line); # split(/\Q$INPUT_SEPARATOR/, $line);
 					my $column_index = 0;
 
 					foreach my $column (@columns) {
 						next if !defined $column;
+						$column =~ s/\\'"'"'/'"'"'/g;	# unescape single quotes - complicated as we are in a bash single-quoted string
+						$column =~ s/\\"/"/g;			# unescape double quotes
+						$column =~ s/(\\+)\1/$1/g;		# unescape backslashes
 						$column = trim_ansi($column);
 
 						if (!defined $column_widths->[$column_index]) {
@@ -163,11 +169,17 @@ column_ansi ()
 				foreach my $line_ref (@stdin) {
 					my $line = $line_ref;
 					$line =~ s/\r?\n?$//;
+					$line =~ s/(\\+)/$1$1/g;		# escape backslashes
+					$line =~ s/"/\\"/g;				# escape double quotes
+					$line =~ s/'"'"'/\\'"'"'/g;		# escape single quotes - complicated as we are in a bash single-quoted string
 					my @columns = quotewords($INPUT_SEPARATOR, 1, $line); # split (/\Q$INPUT_SEPARATOR/, $line);
 					my $column_index = -1;
 
 					foreach my $column (@columns) {
 						next if !defined $column;
+						$column =~ s/\\'"'"'/'"'"'/g;	# unescape single quotes - complicated as we are in a bash single-quoted string
+						$column =~ s/\\"/"/g;			# unescape double quotes
+						$column =~ s/(\\+)\1/$1/g;		# unescape backslashes
 						$column_index++;
 
 						# 2022/04/09 - Hide the column if it is in HIDDEN_COLUMNS

--- a/column_ansi.sh
+++ b/column_ansi.sh
@@ -138,7 +138,8 @@ column_ansi ()
 				my $column_widths = [];
 
 				# First loop: get the width of each column and save it in an array
-				foreach my $line (@stdin) {
+				foreach my $line_ref (@stdin) {
+					my $line = $line_ref;
 					$line =~ s/\r?\n?$//;
 					my @columns = quotewords($INPUT_SEPARATOR, 1, $line); # split(/\Q$INPUT_SEPARATOR/, $line);
 					my $column_index = 0;
@@ -159,7 +160,8 @@ column_ansi ()
 				}
 
 				# Second loop: print the columns
-				foreach my $line (@stdin) {
+				foreach my $line_ref (@stdin) {
+					my $line = $line_ref;
 					$line =~ s/\r?\n?$//;
 					my @columns = quotewords($INPUT_SEPARATOR, 1, $line); # split (/\Q$INPUT_SEPARATOR/, $line);
 					my $column_index = -1;

--- a/column_ansi.sh
+++ b/column_ansi.sh
@@ -140,7 +140,7 @@ column_ansi ()
 				# First loop: get the width of each column and save it in an array
 				foreach my $line (@stdin) {
 					$line =~ s/\r?\n?$//;
-					my @columns = quotewords($INPUT_SEPARATOR, 0, $line); # split(/\Q$INPUT_SEPARATOR/, $line);
+					my @columns = quotewords($INPUT_SEPARATOR, 1, $line); # split(/\Q$INPUT_SEPARATOR/, $line);
 					my $column_index = 0;
 
 					foreach my $column (@columns) {
@@ -161,7 +161,7 @@ column_ansi ()
 				# Second loop: print the columns
 				foreach my $line (@stdin) {
 					$line =~ s/\r?\n?$//;
-					my @columns = quotewords($INPUT_SEPARATOR, 0, $line); # split (/\Q$INPUT_SEPARATOR/, $line);
+					my @columns = quotewords($INPUT_SEPARATOR, 1, $line); # split (/\Q$INPUT_SEPARATOR/, $line);
 					my $column_index = -1;
 
 					foreach my $column (@columns) {

--- a/tests/test_column_ansi.sh
+++ b/tests/test_column_ansi.sh
@@ -163,6 +163,12 @@ System               :  \tABC Name   :
 UEFI System Check    :         \tBootorder  :
 System Up Time       :  \tRotation   :
 ";
+
+	string3='\\Backslash@"Quotes"@Backslash\\@Separator "@" in quotes@'"Separator '@' in quotes"
+	# Expect: \Backslash | "Quotes" | Backslash\ | Separator "@" in quotes | Separator '@' in quotes
+
+	string4='Dangling quotes "'"'"
+	# Expect: Dangling quotes "'
 	
 	printf "\033[1mCOLUMN (Original):\033[0m\n";
 	time echo "${string}" | column -t -s "${SEPARATOR}";
@@ -186,6 +192,16 @@ System Up Time       :  \tRotation   :
 
 	printf "\033[1mCOLUMN (Custom - mine): Empty Data without Ansi Codes\033[0m\n"
 	time echo -e -n "${string2}" | column_ansi -t -s $'\t'
+	printf "\n\n";
+
+
+	printf "\033[1mCOLUMN (Custom - mine): Backslashes and quotes\033[0m\n"
+	time echo -e -n "${string3}" | column_ansi -o " | " -s '@'
+	printf "\n\n";
+
+
+	printf "\033[1mCOLUMN (Custom - mine): Dangling quotes\033[0m\n"
+	time echo -e -n "${string4}" | column_ansi -o " | " -s '@'
 	printf "\n\n";
 else
 	# If script is NOT being sourced, then start the column_ansi function

--- a/tests/test_column_ansi.sh
+++ b/tests/test_column_ansi.sh
@@ -2,7 +2,7 @@
 
 # For the tests to work we need the function `column_ansi` available from the downloaded script.
 # Sourcing won't execute the function 
-source "../column_ansi.sh" || exit 1;
+source "../column_ansi.sh" || exit 1
 
 # @description:    Bash version of column (similar to the one from util-linux) which works with color codes
 # @author:         NORMAN GEIST
@@ -62,7 +62,7 @@ function column2 () (
 	function pad()
 	{
 	for ((i=0; i<$1; i++))
-	do 
+	do
 	echo -n " "
 	done
 	}
@@ -138,9 +138,9 @@ _trim_all_ANSI () {
 if [[ $# -eq 0 ]]; then
 	SEPARATOR=":"
 	string=$(
-		printf "First column${SEPARATOR}Second${SEPARATOR}3rd column${SEPARATOR}\033[0;31mErrors\033[0m${SEPARATOR}Notes\n"; 
-		printf "Test value${SEPARATOR}\033[1;35mColored output\033[0m${SEPARATOR}ABC${SEPARATOR}YES${SEPARATOR}Very long text\n";
-	);
+		printf "First column${SEPARATOR}Second${SEPARATOR}3rd column${SEPARATOR}\033[0;31mErrors\033[0m${SEPARATOR}Notes\n"
+		printf "Test value${SEPARATOR}\033[1;35mColored output\033[0m${SEPARATOR}ABC${SEPARATOR}YES${SEPARATOR}Very long text\n"
+	)
 	sanitized_string="$(echo "${string}" | _trim_all_ANSI)"
 
  	string2="
@@ -162,51 +162,51 @@ Out-Server           :  \tMain  check:
 System               :  \tABC Name   :
 UEFI System Check    :         \tBootorder  :
 System Up Time       :  \tRotation   :
-";
+"
 
 	string3='\\Backslash@"Quotes"@Backslash\\@Separator "@" in quotes@'"Separator '@' in quotes"
 	# Expect: \Backslash | "Quotes" | Backslash\ | Separator "@" in quotes | Separator '@' in quotes
 
 	string4='Dangling quotes "'"'"
 	# Expect: Dangling quotes "'
-	
-	printf "\033[1mCOLUMN (Original):\033[0m\n";
-	time echo "${string}" | column -t -s "${SEPARATOR}";
-	printf "\n\n";
+
+	printf "\033[1mCOLUMN (Original):\033[0m\n"
+	time echo "${string}" | column -t -s "${SEPARATOR}"
+	printf "\n\n"
 
 
-	printf "\033[1mCOLUMN (Original - Without ANSI):\033[0m\n";
-	time echo "${sanitized_string}" | column -t -s "${SEPARATOR}";
-	printf "\n\n";
+	printf "\033[1mCOLUMN (Original - Without ANSI):\033[0m\n"
+	time echo "${sanitized_string}" | column -t -s "${SEPARATOR}"
+	printf "\n\n"
 
 
-	printf "\033[1mCOLUMN (Custom - @NORMAN GEIST):\033[0m\n";
-	time echo "${string}" | column2 -s "${SEPARATOR}";
-	printf "\n\n";
+	printf "\033[1mCOLUMN (Custom - @NORMAN GEIST):\033[0m\n"
+	time echo "${string}" | column2 -s "${SEPARATOR}"
+	printf "\n\n"
 
 
-	printf "\033[1mCOLUMN (Custom - mine):\033[0m\n";
-	time echo "${string}" | column_ansi -s "${SEPARATOR}";
-	printf "\n\n";
+	printf "\033[1mCOLUMN (Custom - mine):\033[0m\n"
+	time echo "${string}" | column_ansi -s "${SEPARATOR}"
+	printf "\n\n"
 
 
 	printf "\033[1mCOLUMN (Custom - mine): Empty Data without Ansi Codes\033[0m\n"
 	time echo -e -n "${string2}" | column_ansi -t -s $'\t'
-	printf "\n\n";
+	printf "\n\n"
 
 
 	printf "\033[1mCOLUMN (Custom - mine): Backslashes and quotes\033[0m\n"
 	time echo -e -n "${string3}" | column_ansi -o " | " -s '@'
-	printf "\n\n";
+	printf "\n\n"
 
 
 	printf "\033[1mCOLUMN (Custom - mine): Dangling quotes\033[0m\n"
 	time echo -e -n "${string4}" | column_ansi -o " | " -s '@'
-	printf "\n\n";
+	printf "\n\n"
 else
 	# If script is NOT being sourced, then start the column_ansi function
 	# Source: https://stackoverflow.com/a/28776166/8965861
 	if ! (return 0 2>/dev/null); then
-		column_ansi "$@";
+		column_ansi "$@"
 	fi
 fi

--- a/tests/test_column_ansi.sh
+++ b/tests/test_column_ansi.sh
@@ -165,7 +165,8 @@ System Up Time       :  \tRotation   :
 "
 
 	string3='\Backslash@"Quotes"@Backslash\@Separator "@" in quotes@'"Separator '@' in quotes"
-	# Expect: \Backslash | "Quotes" | Backslash\ | Separator "@" in quotes | Separator '@' in quotes
+	# Expect: \Backslash | "Quotes" | Backslash\ | Separator " | " in quotes | Separator ' | ' in quotes
+	# (Quotes should not be parsed - a separator should take effect as a separator even if in quotes)
 
 	string4='Dangling quotes "'"'"
 	# Expect: Dangling quotes "'

--- a/tests/test_column_ansi.sh
+++ b/tests/test_column_ansi.sh
@@ -164,7 +164,7 @@ UEFI System Check    :         \tBootorder  :
 System Up Time       :  \tRotation   :
 "
 
-	string3='\\Backslash@"Quotes"@Backslash\\@Separator "@" in quotes@'"Separator '@' in quotes"
+	string3='\Backslash@"Quotes"@Backslash\@Separator "@" in quotes@'"Separator '@' in quotes"
 	# Expect: \Backslash | "Quotes" | Backslash\ | Separator "@" in quotes | Separator '@' in quotes
 
 	string4='Dangling quotes "'"'"
@@ -196,12 +196,12 @@ System Up Time       :  \tRotation   :
 
 
 	printf "\033[1mCOLUMN (Custom - mine): Backslashes and quotes\033[0m\n"
-	time echo -e -n "${string3}" | column_ansi -o " | " -s '@'
+	time echo -n "${string3}" | column_ansi -o " | " -s '@'
 	printf "\n\n"
 
 
 	printf "\033[1mCOLUMN (Custom - mine): Dangling quotes\033[0m\n"
-	time echo -e -n "${string4}" | column_ansi -o " | " -s '@'
+	time echo -n "${string4}" | column_ansi -o " | " -s '@'
 	printf "\n\n"
 else
 	# If script is NOT being sourced, then start the column_ansi function


### PR DESCRIPTION
These changes attempt to keep quotes and backslashes in the output.  See #6.

I've also removed unnecessary semicolons from the test harness.